### PR TITLE
Add "main" block to manage dependencies when only using NPM

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "map",
     "leaflet"
   ],
+  "main": "dist/leaflet-layerjson.min.js",
   "dependencies": {
     "leaflet": "*"
   },


### PR DESCRIPTION
At the moment, doing an `npm install leaflet-layerjson` and making a `require('leaflet-layerjson') ` within a file static/js/app.js (not at project root level), I get an error when using Browserify.

I do :

    browserify static/js/app.js > static/js/bundle.js

And I get below error
 
    Error: Cannot find module 'leaflet-layerjson' from '/home/thomas/git/leaflet_browserify/static/js'

I could always make a require like `require('leaflet-layerjson/dist/leaflet-layerjson.min.js'); ` in my app.js file to solve but I think it's more clean to declare "main" block within package.json