### PR TITLE
With json like this the last "k" value is "contains", this generate a…

### DIFF
--- a/src/leaflet-layerjson.js
+++ b/src/leaflet-layerjson.js
@@ -270,8 +270,10 @@ L.LayerJSON = L.FeatureGroup.extend({
 
 			that.fire('dataloaded', {data: json});
 
-			for(var k in json)
-				that.addMarker.call(that, json[k]);
+			for (var k in json) {
+			    if (!isNaN(parseFloat(k)) && isFinite(k))
+			        that.addMarker.call(that, json[k]);
+			}
 		});
 	},
 


### PR DESCRIPTION
With json like the following sample the last "k" value is "contains"; this generate a javascript error.
Added the numeric check for "k" value

json sample:

``` javascript
[
  {
    "value": 0.000479060661746189,
    "loc": [
      53.949999999999996,
      11.416549514563076
    ],
    "name": "rel10"
  },
  {
    "value": -0.003874742891639471,
    "loc": [
      54.24999999999999,
      12.08320970873783
    ],
    "name": "rel10"
  },
  {
    "value": 0.00413445383310318,
    "loc": [
      54.55,
      11.916544660194141
    ],
    "name": "rel10"
  },
  {
    "value": -0.0017495272913947701,
    "loc": [
      55.24999999999999,
      10.916554368932008
    ],
    "name": "rel10"
  },
  {
    "value": 0.0007312385714612901,
    "loc": [
      55.349999999999994,
      11.083219417475696
    ],
    "name": "rel10"
  },
  {
    "value": -0.001714763231575489,
    "loc": [
      55.55,
      9.749899029126187
    ],
    "name": "rel10"
  },
  {
    "value": -0.00036571460077539086,
    "loc": [
      55.64999999999999,
      21.083122330097037
    ],
    "name": "rel10"
  },
  {
    "value": -0.005066916346549988,
    "loc": [
      56.05,
      15.5831757281553
    ],
    "name": "rel10"
  },
  {
    "value": -0.0022862276528030634,
    "loc": [
      56.14999999999999,
      10.249894174757252
    ],
    "name": "rel10"
  },
  {
    "value": -0.0012040918227285147,
    "loc": [
      56.14999999999999,
      12.41653980582521
    ],
    "name": "rel10"
  },
  {
    "value": -0.00852535292506218,
    "loc": [
      57.349999999999994,
      17.0831611650485
    ],
    "name": "rel10"
  },
  {
    "value": 0.00023996166419237852,
    "loc": [
      57.55,
      9.916564077669875
    ],
    "name": "rel10"
  },
  {
    "value": -0.0029331129044294357,
    "loc": [
      58.349999999999994,
      11.249884466019388
    ],
    "name": "rel10"
  },
  {
    "value": -0.010104971006512642,
    "loc": [
      58.349999999999994,
      24.416423300970816
    ],
    "name": "rel10"
  },
  {
    "value": -0.010542504489421844,
    "loc": [
      58.949999999999996,
      22.08311262135917
    ],
    "name": "rel10"
  },
  {
    "value": -0.01009722612798214,
    "loc": [
      59.05,
      18.249816504854323
    ],
    "name": "rel10"
  },
  {
    "value": -0.007892047055065632,
    "loc": [
      59.55,
      28.083054368931975
    ],
    "name": "rel10"
  },
  {
    "value": -0.010455531068146229,
    "loc": [
      60.14999999999999,
      24.916418446601885
    ],
    "name": "rel10"
  },
  {
    "value": -0.012959691695868969,
    "loc": [
      61.55,
      21.416452427184414
    ],
    "name": "rel10"
  },
  {
    "value": -0.014973852783441544,
    "loc": [
      63.949999999999996,
      20.91645728155335
    ],
    "name": "rel10"
  },
  {
    "value": -0.01525064930319786,
    "loc": [
      65.05,
      25.24974854368926
    ],
    "name": "rel10"
  }
]
```
